### PR TITLE
Figma plugin PoC: sync Lexicon docs from Figma

### DIFF
--- a/figma-plugin/README.md
+++ b/figma-plugin/README.md
@@ -1,53 +1,68 @@
-# Lexicon Docs Sync — Figma plugin (proof of concept)
+# Lexicon Docs Sync — Figma plugin
 
-A proof of concept for letting **non-technical users refresh the Lexicon docs
-straight from Figma**, instead of running the Node import scripts from a
-terminal.
+Lets a designer push the Lexicon **tokens** from Figma to the docs site **as a
+pull request**, with no terminal, no git and no token handling.
 
-## Why a plugin
+```
+Designer in Figma → "Sync Foundations → open PR"
+   → plugin reads the variables (native API, no REST token)
+   → UI POSTs the generated JSON to the figma-sync Netlify function
+   → function commits the files on a branch and opens a PR   (GitHub token stays server-side)
+   → Netlify builds → merge → live
+```
 
-A plugin runs inside Figma with the designer's session, so it reads the data
-the docs need **natively** — and crucially, it can read **design variables
-without a REST token or an Enterprise plan**, which is exactly what forces the
-current token extraction through the desktop MCP. It also reads component-set
-variants and can export images.
+The plugin reads design variables with the Figma API directly, so it needs **no
+REST token and no Enterprise plan** (which is what blocks the headless scripts).
 
-This PoC does the **extract + preview** half: it shows the JSON it would
-produce. It does **not** yet write to the repo — that next step is a GitHub App
-/ serverless endpoint that turns this JSON into a pull request, after which
-Netlify rebuilds.
+## Pieces
 
-## What it extracts
-
-- **Tokens** — every local variable as `"Group/name": value` (colors → hex,
-  numbers → value), grouped for display. Run it in the **Lexicon Foundations**
-  file to see the full token set.
-- **Component variants** — every component set on the current page with its
-  variant axes and count, parsed from the `Prop=Value` names. Run it on a
-  **Lexicon Components** page to see them.
-- A **Copy JSON** button with the combined result (the same shape the docs data
-  files use).
-
-## Try it
-
-1. Open the **Figma desktop app** and the Lexicon Foundations (or Components) file.
-2. Menu → **Plugins → Development → Import plugin from manifest…**
-3. Pick `figma-plugin/manifest.json` from this repo.
-4. Run **Plugins → Development → Lexicon Docs Sync (PoC)**.
-5. Click **Extract from this file** → review the grouped summary + JSON, **Copy JSON**.
-
-## Files
-
-| File | Role |
+| Where | What |
 |---|---|
-| `manifest.json` | plugin metadata (no network access in the PoC) |
-| `code.js` | sandbox code — reads variables / component sets via the Figma API |
-| `ui.html` | the panel UI — runs Extract, renders the preview + Copy JSON |
+| `figma-plugin/` | the plugin: `manifest.json`, `code.js` (reads variables, builds the files), `ui.html` (settings + Sync button + PR link) |
+| `netlify/functions/figma-sync.js` | the endpoint: validates a secret, commits the files, opens a PR. No deps (uses `fetch` + the GitHub API). |
 
-## Next step (not in this PoC)
+## One-time setup (technical, done once)
 
-Add `networkAccess.allowedDomains` + a "Sync to docs" button that POSTs the JSON
-to a small **GitHub App / serverless** endpoint, which commits the generated
-`src/data/figma-components/*.json`, `src/data/figma-foundations/*.json` and the
-exported images on a branch and opens a **PR** (so changes are reviewed before
-they hit the public site). The export images would use `node.exportAsync()`.
+**1. Netlify environment variables** (Site settings → Environment variables):
+
+| Var | Value |
+|---|---|
+| `GITHUB_TOKEN` | a token with `repo` scope (contents + pull requests) on `liferay-design/liferay.design` — ideally a **GitHub App** installation token or a fine-grained PAT |
+| `SYNC_SECRET` | any random string; the plugin must send the same value |
+| `GITHUB_BASE` | base branch for the PR. **Set to `migration-to-astro`** until the Astro migration is merged (that's where the docs data lives); then `master`. Defaults to `master`. |
+| `GITHUB_REPO` | optional, defaults to `liferay-design/liferay.design` |
+
+The function deploys with the site at:
+`https://<your-netlify-site>/.netlify/functions/figma-sync`
+(on a deploy preview it's `https://<deploy-preview-url>/.netlify/functions/figma-sync`).
+
+**2. Plugin connection** (each designer, once): open the plugin → **Connection**
+→ paste the endpoint URL + the `SYNC_SECRET` → **Save connection** (stored in
+Figma's `clientStorage`, never committed).
+
+## Use it
+
+1. Figma desktop → open the **Lexicon Foundations** file.
+2. **Plugins → Development → Import plugin from manifest…** → `figma-plugin/manifest.json` (first time only).
+3. Run the plugin → **↑ Sync Foundations → open PR**.
+4. Follow the **review it ↗** link to the PR. Merge it → Netlify deploys.
+
+(**Preview** shows what it will extract without sending anything.)
+
+## Security
+
+- The GitHub token lives only in Netlify env vars — never in the plugin.
+- The function rejects requests without the right `SYNC_SECRET`, and only writes
+  paths under `astro/src/data/figma-foundations/`, `astro/src/data/figma-components/`
+  and `static/images/lexicon/figma/`.
+- It always opens a **PR** (never pushes to the base branch), so changes are
+  reviewed before they reach the public site.
+
+## Scope & next step
+
+- **Done:** Foundations tokens (colors, typography, spacing, border-radius,
+  opacity, shadow) — produces the 6 `figma-foundations/*.json` files.
+- **Next:** Figma Components — same flow plus component-set variants and **image
+  export** (`node.exportAsync` → committed as base64; the function already
+  accepts `contentBase64`). The function is generic, so this is mostly plugin
+  work.

--- a/figma-plugin/README.md
+++ b/figma-plugin/README.md
@@ -1,0 +1,53 @@
+# Lexicon Docs Sync — Figma plugin (proof of concept)
+
+A proof of concept for letting **non-technical users refresh the Lexicon docs
+straight from Figma**, instead of running the Node import scripts from a
+terminal.
+
+## Why a plugin
+
+A plugin runs inside Figma with the designer's session, so it reads the data
+the docs need **natively** — and crucially, it can read **design variables
+without a REST token or an Enterprise plan**, which is exactly what forces the
+current token extraction through the desktop MCP. It also reads component-set
+variants and can export images.
+
+This PoC does the **extract + preview** half: it shows the JSON it would
+produce. It does **not** yet write to the repo — that next step is a GitHub App
+/ serverless endpoint that turns this JSON into a pull request, after which
+Netlify rebuilds.
+
+## What it extracts
+
+- **Tokens** — every local variable as `"Group/name": value` (colors → hex,
+  numbers → value), grouped for display. Run it in the **Lexicon Foundations**
+  file to see the full token set.
+- **Component variants** — every component set on the current page with its
+  variant axes and count, parsed from the `Prop=Value` names. Run it on a
+  **Lexicon Components** page to see them.
+- A **Copy JSON** button with the combined result (the same shape the docs data
+  files use).
+
+## Try it
+
+1. Open the **Figma desktop app** and the Lexicon Foundations (or Components) file.
+2. Menu → **Plugins → Development → Import plugin from manifest…**
+3. Pick `figma-plugin/manifest.json` from this repo.
+4. Run **Plugins → Development → Lexicon Docs Sync (PoC)**.
+5. Click **Extract from this file** → review the grouped summary + JSON, **Copy JSON**.
+
+## Files
+
+| File | Role |
+|---|---|
+| `manifest.json` | plugin metadata (no network access in the PoC) |
+| `code.js` | sandbox code — reads variables / component sets via the Figma API |
+| `ui.html` | the panel UI — runs Extract, renders the preview + Copy JSON |
+
+## Next step (not in this PoC)
+
+Add `networkAccess.allowedDomains` + a "Sync to docs" button that POSTs the JSON
+to a small **GitHub App / serverless** endpoint, which commits the generated
+`src/data/figma-components/*.json`, `src/data/figma-foundations/*.json` and the
+exported images on a branch and opens a **PR** (so changes are reviewed before
+they hit the public site). The export images would use `node.exportAsync()`.

--- a/figma-plugin/README.md
+++ b/figma-plugin/README.md
@@ -8,7 +8,7 @@ Designer in Figma → "Sync Foundations → open PR"
    → plugin reads the variables (native API, no REST token)
    → UI POSTs the generated JSON to the figma-sync Netlify function
    → function commits the files on a branch and opens a PR   (GitHub token stays server-side)
-   → Netlify builds → merge → live
+   → Netlify builds the preview → review → merge → live
 ```
 
 The plugin reads design variables with the Figma API directly, so it needs **no
@@ -21,33 +21,136 @@ REST token and no Enterprise plan** (which is what blocks the headless scripts).
 | `figma-plugin/` | the plugin: `manifest.json`, `code.js` (reads variables, builds the files), `ui.html` (settings + Sync button + PR link) |
 | `netlify/functions/figma-sync.js` | the endpoint: validates a secret, commits the files, opens a PR. No deps (uses `fetch` + the GitHub API). |
 
-## One-time setup (technical, done once)
+---
 
-**1. Netlify environment variables** (Site settings → Environment variables):
+## ⚠️ STATUS — read this first (2026-06)
 
-| Var | Value |
+The flow is **built and pushed but NOT yet wired up end-to-end.** What's done and
+what's pending:
+
+- ✅ Plugin (`code.js` / `ui.html` / `manifest.json`) — committed on branch
+  **`figma-plugin-poc`** (PR #1332). Syntax-validated.
+- ✅ Backend function `netlify/functions/figma-sync.js` — committed on the same
+  branch. Syntax-validated. **Never executed against real GitHub yet.**
+- ❌ **Not deployed to the production domain.** The function currently lives
+  ONLY on `figma-plugin-poc`. It is NOT on `master` and NOT on
+  `migration-to-astro`. So `https://liferaydesign.netlify.app/.netlify/functions/figma-sync`
+  returns **404** — that's expected, the production branch doesn't have the
+  function.
+- ❌ Netlify env vars (`GITHUB_TOKEN`, `SYNC_SECRET`, `GITHUB_BASE`) not set yet.
+- ❌ Plugin never imported/run in Figma yet.
+
+### How to test it before merging (deploy-preview URL)
+
+Every PR gets its own Netlify deploy with its own functions. Use the **deploy
+preview** URL of PR #1332, not the production domain:
+
+```
+https://deploy-preview-1332--liferaydesign.netlify.app/.netlify/functions/figma-sync
+```
+
+Open it in a browser: **"Method not allowed"** = the function is live (it only
+accepts POST). **404** = that deploy didn't build the function yet.
+
+### Pending fix to make it work on the PRODUCTION domain (the "B" task)
+
+The function must live on the branch that becomes production — the Astro branch —
+not on a separate PoC branch. Otherwise, after Astro merges to `master`, the
+public site will STILL 404 on the function.
+
+Detail: on `migration-to-astro`, `netlify.toml` has `base = "astro"`, so Netlify
+resolves the functions directory **relative to `astro/`**. So the move is:
+
+1. Put the function at **`astro/netlify/functions/figma-sync.js`** (under base).
+2. Add to **`astro/netlify.toml`**:
+   ```toml
+   [functions]
+     directory = "netlify/functions"
+     node_bundler = "esbuild"
+   ```
+3. Commit on `migration-to-astro` (PR #1331). Then the production domain serves
+   the function once that PR merges.
+
+(The copy on `figma-plugin-poc` can stay for PoC testing, or be removed once the
+function lives on the Astro branch.)
+
+---
+
+## The two "Connection" fields in the plugin
+
+The plugin can't hold the GitHub token (any holder of the plugin could write to
+the repo). So the plugin never talks to GitHub directly — it sends the files to
+*your* Netlify function, and the function (which holds the token, server-side)
+opens the PR. To do that the plugin needs two things:
+
+| Field | What it is | Example |
+|---|---|---|
+| **Sync endpoint URL** | the address of your function on Netlify — where the plugin sends the JSON | `https://liferaydesign.netlify.app/.netlify/functions/figma-sync` (or the deploy-preview URL while testing) |
+| **Sync secret** | a shared password; the plugin sends it on every request, the function compares it to its own `SYNC_SECRET` and rejects (401) if it doesn't match — the only thing stopping a stranger from using your function | a random string you invent, e.g. `lexicon-sync-9f2k7x` |
+
+**The plugin's `Sync secret` must be the exact same value as the `SYNC_SECRET`
+env var in Netlify.** They are two sides of the same password.
+
+---
+
+## PART 1 — One-time setup (technical, done once, ~10 min)
+
+### Step 1 — Create a GitHub token
+This is the token the function uses to open PRs. It lives only in Netlify, never
+in the plugin.
+
+1. GitHub → your avatar → **Settings** → **Developer settings** → **Personal
+   access tokens** → **Fine-grained tokens** → **Generate new token**.
+2. **Repository access** → *Only select repositories* → `liferay-design/liferay.design`.
+3. **Permissions**:
+   - **Contents**: Read and write
+   - **Pull requests**: Read and write
+4. Generate and **copy** the token (`github_pat_…`) — shown only once.
+
+### Step 2 — Invent the secret
+Any random string, e.g. `lexicon-sync-9f2k7x`. Write it down — you'll use it
+twice (Netlify + plugin).
+
+### Step 3 — Set the Netlify environment variables
+Netlify → your site → **Site configuration → Environment variables → Add a
+variable**:
+
+| Key | Value |
 |---|---|
-| `GITHUB_TOKEN` | a token with `repo` scope (contents + pull requests) on `liferay-design/liferay.design` — ideally a **GitHub App** installation token or a fine-grained PAT |
-| `SYNC_SECRET` | any random string; the plugin must send the same value |
-| `GITHUB_BASE` | base branch for the PR. **Set to `migration-to-astro`** until the Astro migration is merged (that's where the docs data lives); then `master`. Defaults to `master`. |
+| `GITHUB_TOKEN` | the token from Step 1 (`repo`: Contents + Pull requests) |
+| `SYNC_SECRET` | the secret from Step 2 (must equal the plugin's "Sync secret") |
+| `GITHUB_BASE` | **`migration-to-astro`** for now (the docs data lives there); switch to `master` after the Astro migration merges. Defaults to `master`. |
 | `GITHUB_REPO` | optional, defaults to `liferay-design/liferay.design` |
 
-The function deploys with the site at:
-`https://<your-netlify-site>/.netlify/functions/figma-sync`
-(on a deploy preview it's `https://<deploy-preview-url>/.netlify/functions/figma-sync`).
+### Step 4 — Deploy
+The function only exists after Netlify deploys with these vars and the
+`[functions]` config present on the deployed branch. The endpoint is then:
+```
+https://<your-netlify-site>/.netlify/functions/figma-sync
+```
+Sanity check: opening that URL in a browser should say **"Method not allowed"**
+(it only accepts POST). That means it's alive.
 
-**2. Plugin connection** (each designer, once): open the plugin → **Connection**
-→ paste the endpoint URL + the `SYNC_SECRET` → **Save connection** (stored in
-Figma's `clientStorage`, never committed).
+---
 
-## Use it
+## PART 2 — Use it (each designer)
 
-1. Figma desktop → open the **Lexicon Foundations** file.
-2. **Plugins → Development → Import plugin from manifest…** → `figma-plugin/manifest.json` (first time only).
-3. Run the plugin → **↑ Sync Foundations → open PR**.
-4. Follow the **review it ↗** link to the PR. Merge it → Netlify deploys.
+### Step 5 — Import the plugin (first time only)
+1. Figma **desktop** → open the **Lexicon Foundations** file.
+2. **Plugins → Development → Import plugin from manifest…** → `figma-plugin/manifest.json`.
 
-(**Preview** shows what it will extract without sending anything.)
+### Step 6 — Connect (first time per person)
+1. Run the plugin → **Connection**.
+2. **Sync endpoint URL** → paste the URL from Step 4 (or the deploy-preview URL).
+3. **Sync secret** → paste the secret from Step 2.
+4. **Save connection** (stored in Figma `clientStorage`, never committed).
+
+### Step 7 — Sync
+1. (Optional) **Preview** — shows what it will extract without sending anything.
+2. **↑ Sync Foundations → open PR**.
+3. Follow the **review it ↗** link to the PR. Merge it → Netlify deploys.
+
+---
 
 ## Security
 
@@ -58,11 +161,13 @@ Figma's `clientStorage`, never committed).
 - It always opens a **PR** (never pushes to the base branch), so changes are
   reviewed before they reach the public site.
 
-## Scope & next step
+## Scope & next steps
 
 - **Done:** Foundations tokens (colors, typography, spacing, border-radius,
   opacity, shadow) — produces the 6 `figma-foundations/*.json` files.
-- **Next:** Figma Components — same flow plus component-set variants and **image
+- **Next — deploy:** the "B" task above (move the function onto the Astro branch
+  so the production domain serves it), set the Netlify env vars, run it once.
+- **Next — Components:** same flow plus component-set variants and **image
   export** (`node.exportAsync` → committed as base64; the function already
   accepts `contentBase64`). The function is generic, so this is mostly plugin
   work.

--- a/figma-plugin/code.js
+++ b/figma-plugin/code.js
@@ -1,0 +1,93 @@
+// Lexicon Docs Sync — proof of concept.
+//
+// Runs in the Figma sandbox with the signed-in user's session, so it can read
+// design variables, component-set variants and export images *natively* — no
+// REST token, no Enterprise scope (which is exactly what blocks the headless
+// scripts today). This PoC only EXTRACTS the data and shows the JSON it would
+// produce; wiring it to a GitHub App / PR is the next step.
+
+figma.showUI(__html__, { width: 520, height: 680, themeColors: true })
+
+const round = n => Math.round(n * 255)
+const hex2 = n => round(n).toString(16).padStart(2, '0')
+function rgbaToHex(c) {
+	const base = `#${hex2(c.r)}${hex2(c.g)}${hex2(c.b)}`
+	return c.a === undefined || c.a === 1 ? base : base + hex2(c.a)
+}
+
+// Resolve a variable's value in the collection's default mode, following one
+// level of alias (mirrors how the docs token map reads).
+async function resolveValue(variable, collectionsById) {
+	const col = collectionsById[variable.variableCollectionId]
+	const modeId = col ? col.defaultModeId : Object.keys(variable.valuesByMode)[0]
+	let val = variable.valuesByMode[modeId]
+	if (val && typeof val === 'object' && val.type === 'VARIABLE_ALIAS') {
+		const ref = await figma.variables.getVariableByIdAsync(val.id)
+		if (ref) return resolveValue(ref, collectionsById)
+	}
+	if (variable.resolvedType === 'COLOR' && val && typeof val === 'object') return rgbaToHex(val)
+	if (variable.resolvedType === 'FLOAT') return String(val)
+	return String(val)
+}
+
+// All local variables → { "Group/name": value }, grouped for display by the
+// first path segment (Color, Spacing, …).
+async function extractTokens() {
+	const [vars, collections] = await Promise.all([
+		figma.variables.getLocalVariablesAsync(),
+		figma.variables.getLocalVariableCollectionsAsync(),
+	])
+	const byId = Object.fromEntries(collections.map(c => [c.id, c]))
+	const tokens = {}
+	for (const v of vars) tokens[v.name] = await resolveValue(v, byId)
+	const groups = {}
+	for (const [name, value] of Object.entries(tokens)) {
+		const g = name.split('/')[0] || 'Other'
+		;(groups[g] = groups[g] || []).push({ name, value })
+	}
+	return { count: Object.keys(tokens).length, tokens, groups }
+}
+
+// Component sets on the current page → variant axes + count, parsed from the
+// "Prop=Value, Prop2=Value2" child names.
+function extractComponentSets() {
+	const sets = figma.currentPage.findAllWithCriteria({ types: ['COMPONENT_SET'] })
+	return sets.map(set => {
+		const variants = set.children.filter(c => c.type === 'COMPONENT')
+		const axes = {}
+		for (const c of variants) {
+			for (const part of c.name.split(',')) {
+				const i = part.indexOf('=')
+				if (i === -1) continue
+				const key = part.slice(0, i).trim()
+				const value = part.slice(i + 1).trim()
+				if (!key || !value) continue
+				;(axes[key] = axes[key] || new Set()).add(value)
+			}
+		}
+		return {
+			name: set.name,
+			nodeId: set.id,
+			variantCount: variants.length,
+			properties: Object.entries(axes).map(([name, values]) => ({ name, values: [...values] })),
+		}
+	})
+}
+
+figma.ui.onmessage = async msg => {
+	if (msg.type === 'extract') {
+		try {
+			const tokens = await extractTokens()
+			const componentSets = extractComponentSets()
+			figma.ui.postMessage({
+				type: 'result',
+				fileName: figma.root.name,
+				page: figma.currentPage.name,
+				tokens,
+				componentSets,
+			})
+		} catch (e) {
+			figma.ui.postMessage({ type: 'error', message: String((e && e.message) || e) })
+		}
+	}
+}

--- a/figma-plugin/code.js
+++ b/figma-plugin/code.js
@@ -1,37 +1,42 @@
-// Lexicon Docs Sync — proof of concept.
+// Lexicon Docs Sync — Figma plugin (sandbox side).
 //
-// Runs in the Figma sandbox with the signed-in user's session, so it can read
-// design variables, component-set variants and export images *natively* — no
-// REST token, no Enterprise scope (which is exactly what blocks the headless
-// scripts today). This PoC only EXTRACTS the data and shows the JSON it would
-// produce; wiring it to a GitHub App / PR is the next step.
+// Runs with the designer's session, so it reads variables / component variants
+// / images natively — no REST token, no Enterprise scope. It builds the docs
+// data files and hands them to the UI, which POSTs them to the figma-sync
+// Netlify function (the only side that can do network requests). The function
+// opens a PR; Netlify then rebuilds the site.
 
-figma.showUI(__html__, { width: 520, height: 680, themeColors: true })
+figma.showUI(__html__, { width: 540, height: 760, themeColors: true })
 
-const round = n => Math.round(n * 255)
-const hex2 = n => round(n).toString(16).padStart(2, '0')
-function rgbaToHex(c) {
-	const base = `#${hex2(c.r)}${hex2(c.g)}${hex2(c.b)}`
-	return c.a === undefined || c.a === 1 ? base : base + hex2(c.a)
-}
+const FOUNDATIONS_KEY = 'uJmaBABXsx9voFQEdn20Di'
 
-// Resolve a variable's value in the collection's default mode, following one
-// level of alias (mirrors how the docs token map reads).
-async function resolveValue(variable, collectionsById) {
-	const col = collectionsById[variable.variableCollectionId]
+// One foundation sub-page per token group. `match` picks the group's variables
+// out of the full local-variable set (the page chrome reuses other tokens).
+const FOUNDATIONS = [
+	{ name: 'Colors', slug: 'colors', order: 10, pageNodeId: '1:14', match: n => n.startsWith('Color/'), description: 'The Lexicon color palette: brand, neutral and state colors, plus the chart ramps.' },
+	{ name: 'Typography', slug: 'typography', order: 20, pageNodeId: '1:15', match: n => /^\d+\//.test(n), description: 'The type scale — every size/weight pairing used across the system.' },
+	{ name: 'Spacing', slug: 'spacing', order: 30, pageNodeId: '1:16', match: n => n.startsWith('Spacing/'), description: 'The spacing scale used for padding, gaps and layout rhythm.' },
+	{ name: 'Border Radius', slug: 'border-radius', order: 40, pageNodeId: '18:176', match: n => n.startsWith('Border Radius/'), description: 'Corner radius tokens, from subtle rounding to fully pill-shaped.' },
+	{ name: 'Opacity', slug: 'opacity', order: 50, pageNodeId: '245:3', match: n => n.startsWith('Opacity/'), description: 'Translucency tokens for overlays, disabled states and scrims.' },
+	{ name: 'Shadow', slug: 'shadow', order: 60, pageNodeId: '1:17', match: n => n.startsWith('Shadow/'), description: 'Elevation tokens — the drop shadows applied to surfaces by role.' },
+]
+
+const hex2 = n => Math.round(n * 255).toString(16).padStart(2, '0')
+const rgbaToHex = c => `#${hex2(c.r)}${hex2(c.g)}${hex2(c.b)}` + (c.a === undefined || c.a === 1 ? '' : hex2(c.a))
+
+async function resolveValue(variable, byId) {
+	const col = byId[variable.variableCollectionId]
 	const modeId = col ? col.defaultModeId : Object.keys(variable.valuesByMode)[0]
 	let val = variable.valuesByMode[modeId]
 	if (val && typeof val === 'object' && val.type === 'VARIABLE_ALIAS') {
 		const ref = await figma.variables.getVariableByIdAsync(val.id)
-		if (ref) return resolveValue(ref, collectionsById)
+		if (ref) return resolveValue(ref, byId)
 	}
 	if (variable.resolvedType === 'COLOR' && val && typeof val === 'object') return rgbaToHex(val)
 	if (variable.resolvedType === 'FLOAT') return String(val)
 	return String(val)
 }
 
-// All local variables → { "Group/name": value }, grouped for display by the
-// first path segment (Color, Spacing, …).
 async function extractTokens() {
 	const [vars, collections] = await Promise.all([
 		figma.variables.getLocalVariablesAsync(),
@@ -40,19 +45,20 @@ async function extractTokens() {
 	const byId = Object.fromEntries(collections.map(c => [c.id, c]))
 	const tokens = {}
 	for (const v of vars) tokens[v.name] = await resolveValue(v, byId)
+	return tokens
+}
+
+function groupsPreview(tokens) {
 	const groups = {}
 	for (const [name, value] of Object.entries(tokens)) {
 		const g = name.split('/')[0] || 'Other'
 		;(groups[g] = groups[g] || []).push({ name, value })
 	}
-	return { count: Object.keys(tokens).length, tokens, groups }
+	return { count: Object.keys(tokens).length, groups }
 }
 
-// Component sets on the current page → variant axes + count, parsed from the
-// "Prop=Value, Prop2=Value2" child names.
 function extractComponentSets() {
-	const sets = figma.currentPage.findAllWithCriteria({ types: ['COMPONENT_SET'] })
-	return sets.map(set => {
+	return figma.currentPage.findAllWithCriteria({ types: ['COMPONENT_SET'] }).map(set => {
 		const variants = set.children.filter(c => c.type === 'COMPONENT')
 		const axes = {}
 		for (const c of variants) {
@@ -65,29 +71,65 @@ function extractComponentSets() {
 				;(axes[key] = axes[key] || new Set()).add(value)
 			}
 		}
-		return {
-			name: set.name,
-			nodeId: set.id,
-			variantCount: variants.length,
-			properties: Object.entries(axes).map(([name, values]) => ({ name, values: [...values] })),
-		}
+		return { name: set.name, nodeId: set.id, variantCount: variants.length, properties: Object.entries(axes).map(([name, values]) => ({ name, values: [...values] })) }
 	})
 }
 
+// Build the 6 foundation data files from the local variables.
+async function buildFoundationFiles() {
+	const tokens = await extractTokens()
+	const fileKey = figma.fileKey || FOUNDATIONS_KEY
+	const fileName = figma.root.name
+	const files = FOUNDATIONS.map(f => {
+		const groupTokens = {}
+		for (const [name, value] of Object.entries(tokens)) if (f.match(name)) groupTokens[name] = value
+		const data = {
+			name: f.name,
+			slug: f.slug,
+			order: f.order,
+			description: f.description,
+			figma: { fileKey, fileName, pageNodeId: f.pageNodeId },
+			tokens: groupTokens,
+		}
+		return {
+			path: `astro/src/data/figma-foundations/${f.slug}.json`,
+			content: JSON.stringify(data, null, '\t') + '\n',
+			tokenCount: Object.keys(groupTokens).length,
+		}
+	})
+	return { files, fileName }
+}
+
+async function loadConfig() {
+	const endpoint = (await figma.clientStorage.getAsync('endpoint')) || ''
+	const secret = (await figma.clientStorage.getAsync('secret')) || ''
+	figma.ui.postMessage({ type: 'config', endpoint, secret })
+}
+
 figma.ui.onmessage = async msg => {
-	if (msg.type === 'extract') {
-		try {
+	try {
+		if (msg.type === 'init') {
+			await loadConfig()
+		} else if (msg.type === 'save-config') {
+			await figma.clientStorage.setAsync('endpoint', msg.endpoint || '')
+			await figma.clientStorage.setAsync('secret', msg.secret || '')
+			figma.ui.postMessage({ type: 'saved' })
+		} else if (msg.type === 'extract') {
 			const tokens = await extractTokens()
-			const componentSets = extractComponentSets()
 			figma.ui.postMessage({
-				type: 'result',
+				type: 'preview',
 				fileName: figma.root.name,
 				page: figma.currentPage.name,
-				tokens,
-				componentSets,
+				tokens: groupsPreview(tokens),
+				componentSets: extractComponentSets(),
 			})
-		} catch (e) {
-			figma.ui.postMessage({ type: 'error', message: String((e && e.message) || e) })
+		} else if (msg.type === 'build-foundations') {
+			const { files, fileName } = await buildFoundationFiles()
+			figma.ui.postMessage({ type: 'foundation-files', files, fileName })
 		}
+	} catch (e) {
+		figma.ui.postMessage({ type: 'error', message: String((e && e.message) || e) })
 	}
 }
+
+loadConfig()

--- a/figma-plugin/manifest.json
+++ b/figma-plugin/manifest.json
@@ -6,7 +6,7 @@
 	"ui": "ui.html",
 	"editorType": ["figma"],
 	"networkAccess": {
-		"allowedDomains": ["none"],
-		"reasoning": "PoC only extracts data and shows it in the UI; no network calls yet."
+		"allowedDomains": ["https://*.netlify.app", "https://design.liferay.com"],
+		"reasoning": "Sends the generated docs JSON to the figma-sync Netlify function, which opens a PR."
 	}
 }

--- a/figma-plugin/manifest.json
+++ b/figma-plugin/manifest.json
@@ -1,0 +1,12 @@
+{
+	"name": "Lexicon Docs Sync (PoC)",
+	"id": "lexicon-docs-sync-poc",
+	"api": "1.0.0",
+	"main": "code.js",
+	"ui": "ui.html",
+	"editorType": ["figma"],
+	"networkAccess": {
+		"allowedDomains": ["none"],
+		"reasoning": "PoC only extracts data and shows it in the UI; no network calls yet."
+	}
+}

--- a/figma-plugin/ui.html
+++ b/figma-plugin/ui.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8" />
+		<style>
+			html, body { background: #ffffff; color: #1c1c24; }
+			:root { font-family: Inter, "SF Pro Text", -apple-system, sans-serif; font-size: 12px; color: #1c1c24; color-scheme: light; }
+			body { margin: 0; padding: 16px; }
+			h1 { font-size: 14px; margin: 0 0 2px; }
+			p.sub { margin: 0 0 14px; color: #6b6c7e; }
+			button { font: inherit; font-weight: 600; border: 0; border-radius: 6px; padding: 8px 14px; cursor: pointer; }
+			button.primary { background: #0b5fff; color: #fff; }
+			button.primary:hover { background: #004ad7; }
+			button.ghost { background: #f1f2f5; color: #1c1c24; }
+			button.ghost:hover { background: #e2e4ea; }
+			.meta { margin: 14px 0 8px; color: #6b6c7e; }
+			.meta b { color: #1c1c24; }
+			.cards { display: grid; gap: 6px; margin-bottom: 12px; }
+			.card { border: 1px solid #e7e7ed; border-radius: 6px; padding: 8px 10px; }
+			.card .n { font-weight: 600; }
+			.card .d { color: #6b6c7e; }
+			.swrow { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 6px; }
+			.chip { background: #f1f2f5; border-radius: 4px; padding: 1px 6px; font-size: 11px; color: #393a4a; }
+			.dot { display: inline-block; width: 10px; height: 10px; border-radius: 2px; border: 1px solid rgba(0,0,0,0.1); vertical-align: -1px; margin-right: 4px; }
+			pre { background: #1c1c24; color: #e7e7ed; padding: 12px; border-radius: 6px; overflow: auto; max-height: 220px; font-size: 11px; line-height: 1.5; }
+			.row { display: flex; gap: 8px; align-items: center; }
+			.err { color: #da1414; margin-top: 10px; }
+			.empty { color: #9191a1; }
+		</style>
+	</head>
+	<body>
+		<h1>Lexicon Docs Sync <span style="color:#9191a1">(PoC)</span></h1>
+		<p class="sub">Reads variables &amp; component variants from this file — no token needed.</p>
+		<div class="row">
+			<button class="primary" id="extract">Extract from this file</button>
+			<button class="ghost" id="copy" style="display:none">Copy JSON</button>
+		</div>
+		<div id="out"></div>
+
+		<script>
+			const $ = id => document.getElementById(id)
+			let lastJson = ''
+
+			$('extract').onclick = () => parent.postMessage({ pluginMessage: { type: 'extract' } }, '*')
+			function copyText(text) {
+				// navigator.clipboard is usually blocked in the Figma plugin iframe,
+				// so fall back to a hidden textarea + execCommand.
+				const ta = document.createElement('textarea')
+				ta.value = text
+				ta.style.position = 'fixed'
+				ta.style.opacity = '0'
+				document.body.appendChild(ta)
+				ta.focus()
+				ta.select()
+				let ok = false
+				try {
+					ok = document.execCommand('copy')
+				} catch (e) {}
+				document.body.removeChild(ta)
+				if (!ok && navigator.clipboard) navigator.clipboard.writeText(text).catch(() => {})
+			}
+			$('copy').onclick = () => {
+				copyText(lastJson)
+				$('copy').textContent = 'Copied ✓'
+				setTimeout(() => ($('copy').textContent = 'Copy JSON'), 1200)
+			}
+
+			onmessage = event => {
+				const msg = event.data.pluginMessage
+				if (!msg) return
+				if (msg.type === 'error') {
+					$('out').innerHTML = '<p class="err">' + msg.message + '</p>'
+					return
+				}
+				if (msg.type !== 'result') return
+
+				const t = msg.tokens
+				const groups = Object.entries(t.groups)
+				let html =
+					'<p class="meta"><b>' + msg.fileName + '</b> · page “' + msg.page + '”</p>'
+
+				// tokens summary
+				html += '<p class="meta"><b>' + t.count + '</b> variables across <b>' + groups.length + '</b> groups</p>'
+				if (groups.length) {
+					html += '<div class="cards">'
+					for (const [g, items] of groups) {
+						html += '<div class="card"><div class="n">' + g + ' <span class="d">· ' + items.length + '</span></div><div class="swrow">'
+						for (const it of items.slice(0, 12)) {
+							const isColor = /^#/.test(it.value)
+							html += '<span class="chip">' + (isColor ? '<span class="dot" style="background:' + it.value + '"></span>' : '') + it.name.split('/').slice(-1)[0] + '</span>'
+						}
+						if (items.length > 12) html += '<span class="chip">+' + (items.length - 12) + '</span>'
+						html += '</div></div>'
+					}
+					html += '</div>'
+				}
+
+				// component sets
+				html += '<p class="meta"><b>' + msg.componentSets.length + '</b> component sets on this page</p>'
+				if (msg.componentSets.length) {
+					html += '<div class="cards">'
+					for (const s of msg.componentSets) {
+						html += '<div class="card"><div class="n">' + s.name + ' <span class="d">· ' + s.variantCount + ' variants</span></div><div class="swrow">'
+						for (const p of s.properties) html += '<span class="chip">' + p.name + ' (' + p.values.length + ')</span>'
+						html += '</div></div>'
+					}
+					html += '</div>'
+				} else {
+					html += '<p class="empty">None — open a component page to see its variants.</p>'
+				}
+
+				// raw JSON (the data the docs would consume)
+				lastJson = JSON.stringify({ fileName: msg.fileName, page: msg.page, tokens: t.tokens, componentSets: msg.componentSets }, null, 2)
+				html += '<p class="meta">Generated JSON</p><pre>' + lastJson.replace(/</g, '&lt;') + '</pre>'
+
+				$('out').innerHTML = html
+				$('copy').style.display = ''
+			}
+		</script>
+	</body>
+</html>

--- a/figma-plugin/ui.html
+++ b/figma-plugin/ui.html
@@ -7,114 +7,153 @@
 			:root { font-family: Inter, "SF Pro Text", -apple-system, sans-serif; font-size: 12px; color: #1c1c24; color-scheme: light; }
 			body { margin: 0; padding: 16px; }
 			h1 { font-size: 14px; margin: 0 0 2px; }
-			p.sub { margin: 0 0 14px; color: #6b6c7e; }
+			h2 { font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; color: #9191a1; margin: 18px 0 8px; }
+			p.sub { margin: 0 0 8px; color: #6b6c7e; }
+			label { display: block; font-size: 11px; color: #6b6c7e; margin: 8px 0 3px; }
+			input { width: 100%; box-sizing: border-box; font: inherit; padding: 7px 9px; border: 1px solid #cdced9; border-radius: 6px; }
 			button { font: inherit; font-weight: 600; border: 0; border-radius: 6px; padding: 8px 14px; cursor: pointer; }
+			button:disabled { opacity: 0.5; cursor: default; }
 			button.primary { background: #0b5fff; color: #fff; }
-			button.primary:hover { background: #004ad7; }
+			button.primary:hover:not(:disabled) { background: #004ad7; }
 			button.ghost { background: #f1f2f5; color: #1c1c24; }
-			button.ghost:hover { background: #e2e4ea; }
-			.meta { margin: 14px 0 8px; color: #6b6c7e; }
+			button.ghost:hover:not(:disabled) { background: #e2e4ea; }
+			.row { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+			.meta { margin: 12px 0 6px; color: #6b6c7e; }
 			.meta b { color: #1c1c24; }
-			.cards { display: grid; gap: 6px; margin-bottom: 12px; }
+			.cards { display: grid; gap: 6px; }
 			.card { border: 1px solid #e7e7ed; border-radius: 6px; padding: 8px 10px; }
 			.card .n { font-weight: 600; }
-			.card .d { color: #6b6c7e; }
+			.card .d { color: #6b6c7e; font-weight: 400; }
 			.swrow { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 6px; }
 			.chip { background: #f1f2f5; border-radius: 4px; padding: 1px 6px; font-size: 11px; color: #393a4a; }
 			.dot { display: inline-block; width: 10px; height: 10px; border-radius: 2px; border: 1px solid rgba(0,0,0,0.1); vertical-align: -1px; margin-right: 4px; }
-			pre { background: #1c1c24; color: #e7e7ed; padding: 12px; border-radius: 6px; overflow: auto; max-height: 220px; font-size: 11px; line-height: 1.5; }
-			.row { display: flex; gap: 8px; align-items: center; }
-			.err { color: #da1414; margin-top: 10px; }
-			.empty { color: #9191a1; }
+			.status { margin-top: 12px; padding: 9px 11px; border-radius: 6px; font-size: 12px; display: none; }
+			.status.ok { display: block; background: #edf9f0; color: #226a33; }
+			.status.err { display: block; background: #feefef; color: #c31212; }
+			.status.busy { display: block; background: #eef2fa; color: #294f98; }
+			.status a { color: inherit; font-weight: 700; }
+			hr { border: 0; border-top: 1px solid #e7e7ed; margin: 16px 0; }
 		</style>
 	</head>
 	<body>
-		<h1>Lexicon Docs Sync <span style="color:#9191a1">(PoC)</span></h1>
-		<p class="sub">Reads variables &amp; component variants from this file — no token needed.</p>
-		<div class="row">
-			<button class="primary" id="extract">Extract from this file</button>
-			<button class="ghost" id="copy" style="display:none">Copy JSON</button>
+		<h1>Lexicon Docs Sync</h1>
+		<p class="sub">Pushes the Lexicon tokens from this Figma file to the docs site as a pull request.</p>
+
+		<h2>Connection</h2>
+		<label for="endpoint">Sync endpoint URL</label>
+		<input id="endpoint" placeholder="https://liferaydesign.netlify.app/.netlify/functions/figma-sync" />
+		<label for="secret">Sync secret</label>
+		<input id="secret" type="password" placeholder="shared secret" />
+		<div class="row" style="margin-top:8px">
+			<button class="ghost" id="save">Save connection</button>
+			<span id="savedMsg" style="color:#226a33;display:none">Saved ✓</span>
 		</div>
+
+		<hr />
+
+		<h2>Publish</h2>
+		<p class="sub">Run this in the <b>Lexicon Foundations</b> file to update the token docs.</p>
+		<div class="row">
+			<button class="primary" id="sync">↑ Sync Foundations → open PR</button>
+			<button class="ghost" id="preview">Preview</button>
+		</div>
+		<div class="status" id="status"></div>
 		<div id="out"></div>
 
 		<script>
 			const $ = id => document.getElementById(id)
-			let lastJson = ''
+			const post = m => parent.postMessage({ pluginMessage: m }, '*')
+			let endpoint = '', secret = '', syncing = false
 
-			$('extract').onclick = () => parent.postMessage({ pluginMessage: { type: 'extract' } }, '*')
-			function copyText(text) {
-				// navigator.clipboard is usually blocked in the Figma plugin iframe,
-				// so fall back to a hidden textarea + execCommand.
-				const ta = document.createElement('textarea')
-				ta.value = text
-				ta.style.position = 'fixed'
-				ta.style.opacity = '0'
-				document.body.appendChild(ta)
-				ta.focus()
-				ta.select()
-				let ok = false
-				try {
-					ok = document.execCommand('copy')
-				} catch (e) {}
-				document.body.removeChild(ta)
-				if (!ok && navigator.clipboard) navigator.clipboard.writeText(text).catch(() => {})
+			post({ type: 'init' })
+
+			$('save').onclick = () => {
+				endpoint = $('endpoint').value.trim()
+				secret = $('secret').value.trim()
+				post({ type: 'save-config', endpoint, secret })
 			}
-			$('copy').onclick = () => {
-				copyText(lastJson)
-				$('copy').textContent = 'Copied ✓'
-				setTimeout(() => ($('copy').textContent = 'Copy JSON'), 1200)
+			$('preview').onclick = () => post({ type: 'extract' })
+			$('sync').onclick = () => {
+				endpoint = $('endpoint').value.trim()
+				secret = $('secret').value.trim()
+				if (!endpoint || !secret) return setStatus('err', 'Set the endpoint URL and secret first.')
+				setStatus('busy', 'Reading variables from Figma…')
+				syncing = true
+				$('sync').disabled = true
+				post({ type: 'build-foundations' })
+			}
+
+			function setStatus(kind, html) {
+				const el = $('status')
+				el.className = 'status ' + kind
+				el.innerHTML = html
+			}
+
+			async function sendFiles(files, fileName) {
+				try {
+					setStatus('busy', 'Opening a pull request for ' + files.length + ' files…')
+					const res = await fetch(endpoint, {
+						method: 'POST',
+						headers: { 'Content-Type': 'application/json', Authorization: 'Bearer ' + secret },
+						body: JSON.stringify({
+							title: 'Sync Foundations tokens from Figma',
+							branchPrefix: 'figma-sync/foundations',
+							body: 'Token docs generated from “' + fileName + '” by the Lexicon Docs Sync plugin.',
+							files: files.map(f => ({ path: f.path, content: f.content })),
+						}),
+					})
+					const data = await res.json().catch(() => ({}))
+					if (!res.ok || !data.ok) throw new Error(data.error || ('HTTP ' + res.status))
+					setStatus('ok', 'Pull request opened — <a href="' + data.prUrl + '" target="_blank">review it ↗</a>')
+				} catch (e) {
+					setStatus('err', 'Sync failed: ' + (e.message || e))
+				} finally {
+					syncing = false
+					$('sync').disabled = false
+				}
 			}
 
 			onmessage = event => {
 				const msg = event.data.pluginMessage
 				if (!msg) return
-				if (msg.type === 'error') {
-					$('out').innerHTML = '<p class="err">' + msg.message + '</p>'
-					return
+				if (msg.type === 'config') {
+					endpoint = msg.endpoint || ''
+					secret = msg.secret || ''
+					$('endpoint').value = endpoint
+					$('secret').value = secret
+				} else if (msg.type === 'saved') {
+					$('savedMsg').style.display = ''
+					setTimeout(() => ($('savedMsg').style.display = 'none'), 1500)
+				} else if (msg.type === 'error') {
+					setStatus('err', msg.message)
+					syncing = false
+					$('sync').disabled = false
+				} else if (msg.type === 'foundation-files') {
+					$('out').innerHTML = '<p class="meta"><b>' + msg.files.length + '</b> files from “' + msg.fileName + '”: ' + msg.files.map(f => f.path.split('/').pop() + ' (' + f.tokenCount + ')').join(', ') + '</p>'
+					sendFiles(msg.files, msg.fileName)
+				} else if (msg.type === 'preview') {
+					renderPreview(msg)
 				}
-				if (msg.type !== 'result') return
+			}
 
+			function renderPreview(msg) {
 				const t = msg.tokens
 				const groups = Object.entries(t.groups)
-				let html =
-					'<p class="meta"><b>' + msg.fileName + '</b> · page “' + msg.page + '”</p>'
-
-				// tokens summary
-				html += '<p class="meta"><b>' + t.count + '</b> variables across <b>' + groups.length + '</b> groups</p>'
-				if (groups.length) {
-					html += '<div class="cards">'
-					for (const [g, items] of groups) {
-						html += '<div class="card"><div class="n">' + g + ' <span class="d">· ' + items.length + '</span></div><div class="swrow">'
-						for (const it of items.slice(0, 12)) {
-							const isColor = /^#/.test(it.value)
-							html += '<span class="chip">' + (isColor ? '<span class="dot" style="background:' + it.value + '"></span>' : '') + it.name.split('/').slice(-1)[0] + '</span>'
-						}
-						if (items.length > 12) html += '<span class="chip">+' + (items.length - 12) + '</span>'
-						html += '</div></div>'
+				let html = '<p class="meta"><b>' + msg.fileName + '</b> · page “' + msg.page + '” · <b>' + t.count + '</b> variables</p><div class="cards">'
+				for (const [g, items] of groups) {
+					html += '<div class="card"><div class="n">' + g + ' <span class="d">· ' + items.length + '</span></div><div class="swrow">'
+					for (const it of items.slice(0, 12)) {
+						const isColor = /^#/.test(it.value)
+						html += '<span class="chip">' + (isColor ? '<span class="dot" style="background:' + it.value + '"></span>' : '') + it.name.split('/').slice(-1)[0] + '</span>'
 					}
-					html += '</div>'
+					if (items.length > 12) html += '<span class="chip">+' + (items.length - 12) + '</span>'
+					html += '</div></div>'
 				}
-
-				// component sets
-				html += '<p class="meta"><b>' + msg.componentSets.length + '</b> component sets on this page</p>'
+				html += '</div>'
 				if (msg.componentSets.length) {
-					html += '<div class="cards">'
-					for (const s of msg.componentSets) {
-						html += '<div class="card"><div class="n">' + s.name + ' <span class="d">· ' + s.variantCount + ' variants</span></div><div class="swrow">'
-						for (const p of s.properties) html += '<span class="chip">' + p.name + ' (' + p.values.length + ')</span>'
-						html += '</div></div>'
-					}
-					html += '</div>'
-				} else {
-					html += '<p class="empty">None — open a component page to see its variants.</p>'
+					html += '<p class="meta"><b>' + msg.componentSets.length + '</b> component sets on this page</p>'
 				}
-
-				// raw JSON (the data the docs would consume)
-				lastJson = JSON.stringify({ fileName: msg.fileName, page: msg.page, tokens: t.tokens, componentSets: msg.componentSets }, null, 2)
-				html += '<p class="meta">Generated JSON</p><pre>' + lastJson.replace(/</g, '&lt;') + '</pre>'
-
 				$('out').innerHTML = html
-				$('copy').style.display = ''
 			}
 		</script>
 	</body>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,8 @@
 [build.environment]
  PYTHON_VERSION = "3.10"
  NODE_VERSION = "18"
+
+# Serverless functions (the Figma Docs Sync endpoint lives here).
+[functions]
+ directory = "netlify/functions"
+ node_bundler = "esbuild"

--- a/netlify/functions/figma-sync.js
+++ b/netlify/functions/figma-sync.js
@@ -1,0 +1,125 @@
+// Receives a payload from the Lexicon Docs Sync Figma plugin and opens a PR
+// with the generated docs files. The GitHub token never leaves the server.
+//
+// Required Netlify environment variables:
+//   GITHUB_TOKEN  — a token (or GitHub App installation token) with `repo`
+//                   (contents + pull_requests) on the target repository
+//   SYNC_SECRET   — shared secret the plugin must send as `Authorization:
+//                   Bearer <secret>`; rotate freely
+// Optional:
+//   GITHUB_REPO   — "owner/repo" (default "liferay-design/liferay.design")
+//   GITHUB_BASE   — base branch for the PR (default "master")
+//
+// Only paths under these prefixes may be written (so a leaked secret can't
+// commit arbitrary files):
+const ALLOWED_PREFIXES = [
+	'astro/src/data/figma-foundations/',
+	'astro/src/data/figma-components/',
+	'static/images/lexicon/figma/',
+]
+
+const REPO = process.env.GITHUB_REPO || 'liferay-design/liferay.design'
+const BASE = process.env.GITHUB_BASE || 'master'
+const GH = 'https://api.github.com'
+
+const cors = {
+	'Access-Control-Allow-Origin': '*',
+	'Access-Control-Allow-Methods': 'POST, OPTIONS',
+	'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+}
+const json = (statusCode, body) => ({
+	statusCode,
+	headers: { 'Content-Type': 'application/json', ...cors },
+	body: JSON.stringify(body),
+})
+
+async function gh(path, token, method = 'GET', body) {
+	const res = await fetch(`${GH}${path}`, {
+		method,
+		headers: {
+			Authorization: `Bearer ${token}`,
+			Accept: 'application/vnd.github+json',
+			'Content-Type': 'application/json',
+			'User-Agent': 'lexicon-docs-sync',
+		},
+		body: body ? JSON.stringify(body) : undefined,
+	})
+	const data = await res.json().catch(() => ({}))
+	if (!res.ok) throw new Error(`GitHub ${res.status} on ${method} ${path}: ${data.message || ''}`)
+	return data
+}
+
+exports.handler = async event => {
+	if (event.httpMethod === 'OPTIONS') return { statusCode: 204, headers: cors, body: '' }
+	if (event.httpMethod !== 'POST') return json(405, { error: 'Method not allowed' })
+
+	const token = process.env.GITHUB_TOKEN
+	const secret = process.env.SYNC_SECRET
+	if (!token || !secret) return json(500, { error: 'Server not configured (GITHUB_TOKEN / SYNC_SECRET)' })
+
+	const auth = event.headers.authorization || event.headers.Authorization || ''
+	if (auth !== `Bearer ${secret}`) return json(401, { error: 'Unauthorized' })
+
+	let payload
+	try {
+		payload = JSON.parse(event.body || '{}')
+	} catch {
+		return json(400, { error: 'Invalid JSON body' })
+	}
+	const files = Array.isArray(payload.files) ? payload.files : []
+	if (!files.length) return json(400, { error: 'No files in payload' })
+	for (const f of files) {
+		if (!f.path || !ALLOWED_PREFIXES.some(p => f.path.startsWith(p))) {
+			return json(400, { error: `Path not allowed: ${f.path}` })
+		}
+	}
+
+	try {
+		const [owner, repo] = REPO.split('/')
+		const base = `/repos/${owner}/${repo}`
+
+		// 1. base ref → commit → tree
+		const ref = await gh(`${base}/git/ref/heads/${BASE}`, token)
+		const baseSha = ref.object.sha
+		const baseCommit = await gh(`${base}/git/commits/${baseSha}`, token)
+		const baseTree = baseCommit.tree.sha
+
+		// 2. blobs for every file (binary as base64, text as utf-8)
+		const tree = []
+		for (const f of files) {
+			const blob = await gh(`${base}/git/blobs`, token, 'POST', {
+				content: f.contentBase64 != null ? f.contentBase64 : f.content,
+				encoding: f.contentBase64 != null ? 'base64' : 'utf-8',
+			})
+			tree.push({ path: f.path, mode: '100644', type: 'blob', sha: blob.sha })
+		}
+
+		// 3. tree → commit → branch ref
+		const newTree = await gh(`${base}/git/trees`, token, 'POST', { base_tree: baseTree, tree })
+		const stamp = new Date().toISOString().replace(/[:.]/g, '-')
+		const branch = `${(payload.branchPrefix || 'figma-sync').replace(/[^a-zA-Z0-9/_-]/g, '')}-${stamp}`
+		const commit = await gh(`${base}/git/commits`, token, 'POST', {
+			message: payload.title || 'Sync docs from Figma',
+			tree: newTree.sha,
+			parents: [baseSha],
+		})
+		await gh(`${base}/git/refs`, token, 'POST', {
+			ref: `refs/heads/${branch}`,
+			sha: commit.sha,
+		})
+
+		// 4. open the PR
+		const pr = await gh(`${base}/pulls`, token, 'POST', {
+			title: payload.title || 'Sync docs from Figma',
+			head: branch,
+			base: BASE,
+			body:
+				(payload.body || 'Generated from Figma by the Lexicon Docs Sync plugin.') +
+				`\n\n${files.length} file(s) updated.`,
+		})
+
+		return json(200, { ok: true, prUrl: pr.html_url, branch, files: files.length })
+	} catch (e) {
+		return json(502, { error: String((e && e.message) || e) })
+	}
+}


### PR DESCRIPTION
A proof of concept for letting **non-technical users refresh the Lexicon docs straight from Figma**, instead of running the Node import scripts from a terminal.

### Why a plugin
A plugin runs inside Figma with the designer's session, so it reads the data the docs need **natively** — and crucially, it reads **design variables (tokens) without a REST token or an Enterprise plan**, which is exactly what forces today's token extraction through the Figma desktop MCP. It also reads component-set variants and can export images.

### What this PoC does (extract + preview)
- **Tokens** — every local variable as `"Group/name": value`, grouped (colors → hex, numbers → value). Run it in the **Lexicon Foundations** file.
- **Component variants** — each component set on the current page with its variant axes + count, parsed from the `Prop=Value` names. Run it on a **Lexicon Components** page.
- A **Copy JSON** button emitting the same shape the docs data files use (`execCommand` fallback, since the plugin iframe blocks `navigator.clipboard`).

It does **not** write back yet — see next step.

### Try it
1. Figma desktop → open the Lexicon Foundations (or Components) file.
2. **Plugins → Development → Import plugin from manifest…** → `figma-plugin/manifest.json`.
3. Run it → **Extract from this file**.

### Files
`figma-plugin/manifest.json` (no network in the PoC), `code.js` (sandbox/extraction), `ui.html` (panel, forced light theme so it's readable in Figma dark mode), `README.md`.

### Next step (not in this PR)
A "Sync to docs" button that POSTs this JSON (and images via `node.exportAsync`) to a **GitHub App / serverless** endpoint, which commits the generated `figma-components` / `figma-foundations` data + images on a branch and opens a **PR** (reviewed before it hits the public site). Pairs with the Astro docs in #1331.